### PR TITLE
Remove all uses of Date to make benchmarks comparable Protobuff

### DIFF
--- a/Codable/Sources/Benchmark/TaskDto.swift
+++ b/Codable/Sources/Benchmark/TaskDto.swift
@@ -3,11 +3,11 @@ import Foundation
 class TaskClassDto: Codable {
 
     public var id: String?
-    public var createDate: Date?
+    public var createDate: String?
     public var name: String
     public var isFinished: Bool
 
-    init(id: String, createDate: Date, name: String, isFinished: Bool) {
+    init(id: String, createDate: String, name: String, isFinished: Bool) {
         self.id = id
         self.createDate = createDate
         self.name = name

--- a/Codable/Sources/Benchmark/main.swift
+++ b/Codable/Sources/Benchmark/main.swift
@@ -13,7 +13,7 @@ func evaluateProblem(_ name: String, method: () -> Void) {
 }
 
 func getList() -> [TaskClassDto] {
-    let currentDate = Date()
+    let currentDate = Date().description
     var list: [TaskClassDto] = []
     for i in 1...100 {
         list.append(TaskClassDto(id: UUID().uuidString, createDate: currentDate, name: "Task \(i)", isFinished: false))
@@ -23,7 +23,7 @@ func getList() -> [TaskClassDto] {
 }
 
 func getObject() -> TaskClassDto {
-    return TaskClassDto(id: UUID().uuidString, createDate: Date(), name: "Task 1", isFinished: false)
+    return TaskClassDto(id: UUID().uuidString, createDate: Date().description, name: "Task 1", isFinished: false)
 }
 
 var entityJson = TaskJson.getTaskJson()

--- a/HandyJSON/Sources/Benchmark/TaskDto.swift
+++ b/HandyJSON/Sources/Benchmark/TaskDto.swift
@@ -4,7 +4,7 @@ import HandyJSON
 class TaskClassDto: HandyJSON {
 
     public var id: String?
-    public var createDate: Date?
+    public var createDate: String?
     public var name: String
     public var isFinished: Bool
 
@@ -15,7 +15,7 @@ class TaskClassDto: HandyJSON {
         self.isFinished = false
     }
 
-    init(id: String, createDate: Date, name: String, isFinished: Bool) {
+    init(id: String, createDate: String, name: String, isFinished: Bool) {
         self.id = id
         self.createDate = createDate
         self.name = name

--- a/HandyJSON/Sources/Benchmark/main.swift
+++ b/HandyJSON/Sources/Benchmark/main.swift
@@ -14,7 +14,7 @@ func evaluateProblem(_ name: String, method: () -> Void) {
 }
 
 func getList() -> [TaskClassDto] {
-    let currentDate = Date()
+    let currentDate = Date().description
     var list: [TaskClassDto] = []
     for i in 1...100 {
         list.append(TaskClassDto(id: UUID().uuidString, createDate: currentDate, name: "Task \(i)", isFinished: false))
@@ -24,7 +24,7 @@ func getList() -> [TaskClassDto] {
 }
 
 func getObject() -> TaskClassDto {
-    return TaskClassDto(id: UUID().uuidString, createDate: Date(), name: "Task 1", isFinished: false)
+    return TaskClassDto(id: UUID().uuidString, createDate: Date().description, name: "Task 1", isFinished: false)
 }
 
 var entityJson = TaskJson.getTaskJson()

--- a/Marshall/Sources/Benchmark/TaskDto.swift
+++ b/Marshall/Sources/Benchmark/TaskDto.swift
@@ -4,7 +4,7 @@ import Marshal
 class TaskClassDto: Marshaling, Unmarshaling {
 
     public var id: String?
-    public var createDate: Date?
+    public var createDate: String?
     public var name: String
     public var isFinished: Bool
 
@@ -15,7 +15,7 @@ class TaskClassDto: Marshaling, Unmarshaling {
         self.isFinished = false
     }
 
-    init(id: String, createDate: Date, name: String, isFinished: Bool) {
+    init(id: String, createDate: String, name: String, isFinished: Bool) {
         self.id = id
         self.createDate = createDate
         self.name = name
@@ -32,7 +32,7 @@ class TaskClassDto: Marshaling, Unmarshaling {
     func marshaled() -> [String: Any] {
         return [
             "id": id ?? "",
-            "createDate" : DateHelper.toISO8601String(createDate) ?? "",
+            "createDate" : createDate ?? "",
             "name": name,
             "isFinished": isFinished
         ]

--- a/Marshall/Sources/Benchmark/main.swift
+++ b/Marshall/Sources/Benchmark/main.swift
@@ -14,7 +14,7 @@ func evaluateProblem(_ name: String, method: () -> Void) {
 }
 
 func getList() -> [TaskClassDto] {
-    let currentDate = Date()
+    let currentDate = Date().description
     var list: [TaskClassDto] = []
     for i in 1...100 {
         list.append(TaskClassDto(id: UUID().uuidString, createDate: currentDate, name: "Task \(i)", isFinished: false))
@@ -24,7 +24,7 @@ func getList() -> [TaskClassDto] {
 }
 
 func getObject() -> [String: Any] {
-    let entity = TaskClassDto(id: UUID().uuidString, createDate: Date(), name: "Task 1", isFinished: false)
+    let entity = TaskClassDto(id: UUID().uuidString, createDate: Date().description, name: "Task 1", isFinished: false)
     return entity.marshaled()
 }
 

--- a/NetCore/Program.cs
+++ b/NetCore/Program.cs
@@ -14,7 +14,7 @@ namespace NetCore
                 list.Add(new TaskDto
                 {
                     Id = Guid.NewGuid().ToString(),
-                    CreateDate = DateTime.Now,
+                    CreateDate = DateTime.Now.ToString(),
                     Name = $"Task {i}",
                     IsFinished = false
                 });
@@ -28,7 +28,7 @@ namespace NetCore
             return new TaskDto
             {
                 Id = Guid.NewGuid().ToString(),
-                CreateDate = DateTime.Now,
+                CreateDate = DateTime.Now.ToString(),
                 Name = $"Task 1",
                 IsFinished = false
             };

--- a/NetCore/TaskDto.cs
+++ b/NetCore/TaskDto.cs
@@ -5,7 +5,7 @@ namespace NetCore
     class TaskDto 
     {
         public String Id { get; set; }
-        public DateTime CreateDate { get; set; }
+        public String CreateDate { get; set; }
         public String Name { get; set; }
         public bool IsFinished { get; set; }
     }

--- a/ObjectMapper/Sources/Benchmark/TaskDto.swift
+++ b/ObjectMapper/Sources/Benchmark/TaskDto.swift
@@ -4,7 +4,7 @@ import ObjectMapper
 class TaskClassDto: Mappable {
 
     public var id: String?
-    public var createDate: Date?
+    public var createDate: String?
     public var name: String
     public var isFinished: Bool
 
@@ -29,7 +29,7 @@ class TaskClassDto: Mappable {
         self.isFinished     <- map["isFinished"]
     }
 
-    init(id: String, createDate: Date, name: String, isFinished: Bool) {
+    init(id: String, createDate: String, name: String, isFinished: Bool) {
         self.id = id
         self.createDate = createDate
         self.name = name

--- a/ObjectMapper/Sources/Benchmark/main.swift
+++ b/ObjectMapper/Sources/Benchmark/main.swift
@@ -14,7 +14,7 @@ func evaluateProblem(_ name: String, method: () -> Void) {
 }
 
 func getList() -> [TaskClassDto] {
-    let currentDate = Date()
+    let currentDate = Date().description
     var list: [TaskClassDto] = []
     for i in 1...100 {
         list.append(TaskClassDto(id: UUID().uuidString, createDate: currentDate, name: "Task \(i)", isFinished: false))
@@ -24,7 +24,7 @@ func getList() -> [TaskClassDto] {
 }
 
 func getObject() -> TaskClassDto {
-    return TaskClassDto(id: UUID().uuidString, createDate: Date(), name: "Task 1", isFinished: false)
+    return TaskClassDto(id: UUID().uuidString, createDate: Date().description, name: "Task 1", isFinished: false)
 }
 
 var entityJson = TaskJson.getTaskJson()

--- a/PMJSON/Sources/Benchmark/TaskDto.swift
+++ b/PMJSON/Sources/Benchmark/TaskDto.swift
@@ -4,7 +4,7 @@ import PMJSON
 class TaskClassDto: Encodable {
 
     public var id: String?
-    public var createDate: Date?
+    public var createDate: String?
     public var name: String
     public var isFinished: Bool
 
@@ -16,18 +16,13 @@ class TaskClassDto: Encodable {
     }
 
     init(json: JSON) throws {
-
         id = try json.getStringOrNil("id")
-
-        if let createDateValue = try json.getStringOrNil("createDate") {
-            createDate = DateHelper.fromISO8601String(createDateValue)
-        }
-
+        createDate = try json.getStringOrNil("createDate")
         name = try json.getString("name")
         isFinished = try json.getBool("isFinished")
     }
 
-    init(id: String, createDate: Date, name: String, isFinished: Bool) {
+    init(id: String, createDate: String, name: String, isFinished: Bool) {
         self.id = id
         self.createDate = createDate
         self.name = name

--- a/PMJSON/Sources/Benchmark/main.swift
+++ b/PMJSON/Sources/Benchmark/main.swift
@@ -14,7 +14,7 @@ func evaluateProblem(_ name: String, method: () -> Void) {
 }
 
 func getList() -> [TaskClassDto] {
-    let currentDate = Date()
+    let currentDate = Date().description
     var list: [TaskClassDto] = []
     for i in 1...100 {
         list.append(TaskClassDto(id: UUID().uuidString, createDate: currentDate, name: "Task \(i)", isFinished: false))
@@ -24,7 +24,7 @@ func getList() -> [TaskClassDto] {
 }
 
 func getObject() -> TaskClassDto {
-    return TaskClassDto(id: UUID().uuidString, createDate: Date(), name: "Task 1", isFinished: false)
+    return TaskClassDto(id: UUID().uuidString, createDate: Date().description, name: "Task 1", isFinished: false)
 }
 
 var entityJson = TaskJson.getTaskJson()


### PR DESCRIPTION
The Protobuff benchmark was not comparable to the other ones because it wasn't doing the costly operation of parsing the `Date` string. It's still the fastest 😁, but the numbers should be closer now. I didn't update the numbers on the main README as I couldn't run the .NET benchmark.